### PR TITLE
Progress Bar styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RTV-form-styling
-CSS styles for the Rock The Vote (RTV) form. Although the file is uploaded directly to their platform and managed there, we wanted to track changes made to this file in this repository. Additional information on how to customize styles and assets can be found [here](https://www.rockthevote.org/programs-and-partner-resources/tech-for-civic-engagement/online-voter-registration-platform/partner-ovr-tool-faqs/).
+CSS styles for the Rock The Vote (RTV) form. Although the file is uploaded directly to their platform and managed there, we wanted to track changes made to this file in this repository. Ideally, this repo should be updated with the most current styles after they've been submitted on the RTV platform. Additional information on how to customize styles and assets can be found [here](https://www.rockthevote.org/programs-and-partner-resources/tech-for-civic-engagement/online-voter-registration-platform/partner-ovr-tool-faqs/).
 
 Partner form style overrides live in `partner.css` (this must be the name of the file uploaded to the partner portal). This is uploaded and submitted for approval via the RTV partner portal. 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # RTV-form-styling
-CSS styles for the Rock The Vote (RTV) form. Although the file is uploaded directly to their platform and managed there, we wanted to track changes made to this file in this repository. Additional information on how to customize styles and assets can be found [here](https://www.rockthevote.org/programs-and-partner-resources/tech-for-civic-engagement/partner-ovr-tool-faqs/partner-ovr-tool-faqs/).
+CSS styles for the Rock The Vote (RTV) form. Although the file is uploaded directly to their platform and managed there, we wanted to track changes made to this file in this repository. Additional information on how to customize styles and assets can be found [here](https://www.rockthevote.org/programs-and-partner-resources/tech-for-civic-engagement/online-voter-registration-platform/partner-ovr-tool-faqs/).
 
 Partner form style overrides live in `partner.css` (this must be the name of the file uploaded to the partner portal). This is uploaded and submitted for approval via the RTV partner portal. 
 
-To upload the `partner.css` file, you must login:
+To upload the `partner.css` file, you must [login](https://vr.rockthevote.com/login) (credentials are in LastPass):
 
 1. Click **Customize** > **White Label** > **CSS**. 
 2. Upload your file. There is no need to check the **remove** checkbox for the `Not Approved Version` file when uploading your updated file.

--- a/partner.css
+++ b/partner.css
@@ -15,11 +15,17 @@ body {
 }
 
 #header.partner {
-    background-size: 75px 60px; 
+    background-size: 75px 60px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+#header #progress-bar {
+    display: block;
 }
 
 #header {
-    background-position: center center;
     background-image: url(DS_LOGO.svg) !important;
 }
 
@@ -37,6 +43,33 @@ body {
     font-weight: 700;
     text-transform: uppercase;
     margin-bottom: 15px;
+}
+
+/** Progress Bar */
+ol li {
+    display: inline-block;
+    margin: 10px;
+    font-size: 18px;
+    color: #322baa;
+    font-weight: bold;
+    border: 7px solid #322baa;
+    border-radius: 60px;
+    padding: 8px 12px;
+
+}
+
+li.progress-title {
+    display: none;
+}
+
+li.progress-current, li.progress-done {
+    color: #ffffff;
+    background-color: #ff0031;
+}
+
+li.progress-done {
+    font-size: 16px;
+    padding: 8px 10px;
 }
 
 /** Form Error */
@@ -315,18 +348,6 @@ body #footer p a, body #footer p a:visited, body #footer p a:link {
     color: black;
 }
 
-/** Media query breakpoints */
-@media only screen 
-and (min-device-width : 375px) 
-and (max-device-width : 812px)
-and (-webkit-device-pixel-ratio : 3) {
-
-    body #main .required--text {
-        font-style: italic;
-        font-size: 90%;
-    }
-}
-
 @media (max-width: 600px) {
 
     body #main .required--text {
@@ -366,5 +387,35 @@ and (orientation : portrait) {
     .dynamic-step li.width_c.registrant-form__middle-name__line,
     .dynamic-step li.width_c.registrant-form__prev-middle-name__line {
         width: 16% !important;
+    }
+}
+
+/** Media query breakpoints */
+@media only screen 
+and (min-device-width : 375px) 
+and (max-device-width : 812px)
+and (-webkit-device-pixel-ratio : 3) {
+
+    body #main .required--text {
+        font-style: italic;
+        font-size: 90%;
+    }
+}
+
+/** Media query breakpoints */
+@media only screen 
+and (min-device-width : 320px) 
+and (max-device-width : 768px) {
+    #header {
+        background-position: center center;
+    }
+
+    #header.partner {
+        justify-content: center;
+        padding-top: 120px;
+    }
+
+    ol li {
+        margin: 10px 5px;
     }
 }


### PR DESCRIPTION
This PR adds a progress bar to the top of our RTV form and styles it to be inline with existing DS styling on the page.

It also adds a couple small updates to the README doc with extra links/login info.

Small Screen:
<img width="394" alt="Screen Shot 2020-07-30 at 12 12 46 PM" src="https://user-images.githubusercontent.com/15236023/88949494-518bd280-d261-11ea-94c5-eb3a4c1398a8.png">

Medium Screen:
<img width="385" alt="Screen Shot 2020-07-30 at 12 12 33 PM" src="https://user-images.githubusercontent.com/15236023/88949491-4e90e200-d261-11ea-8b7e-6d613057dc3f.png">

Desktop:
<img width="622" alt="Screen Shot 2020-07-30 at 12 12 17 PM" src="https://user-images.githubusercontent.com/15236023/88949476-48026a80-d261-11ea-8db2-d0de9d2937b4.png">
